### PR TITLE
Support new applet theme icons

### DIFF
--- a/src/filetypes/Theme.ts
+++ b/src/filetypes/Theme.ts
@@ -27,6 +27,12 @@ export const allowedFilesInNXTheme = [
     "settings.png",
     "power.dds",
     "power.png",
+    "nso.dds",
+    "nso.png",
+    "card.dds",
+    "card.png",
+    "share.dds",
+    "share.png",
     "lock.dds",
     "lock.png",
 ];


### PR DESCRIPTION
This pull request will allow the new files in a theme that will be supported if exelix11/SwitchThemeInjector#159 gets merged,

Based on searching across the repositories, I think this is the only location in themezer that needs to be updated for this.